### PR TITLE
remove comment reference to non existing code

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,8 +63,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
+    // This method is rerun every time setState is called.
     //
     // The Flutter framework has been optimized to make rerunning build methods
     // fast, so that you can just rebuild anything that needs updating rather


### PR DESCRIPTION
the comment reference to "_incrementCounter" is harmful for easy understanding, since it does not exist in this template. Probably it did in an example that it was partially copied from.