### PR TITLE
generate ABIs for x86 and x86_64 by default

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,11 +86,13 @@ dependencies {
         workingDir "../../native"
         environment ANDROID_NDK_HOME: "$ANDROID_NDK"
         commandLine 'cargo', 'ndk',
-            //    Uncomment to enable these ABIs as required.
-            //    '-t', 'x86',
-            //    '-t', 'x86_64',
+                // the below 2 ABIs are used for target Android devices
                 '-t', 'armeabi-v7a',
                 '-t', 'arm64-v8a',
+                // the below 2 ABIs are usually used for Android simulators,
+                // comment these ABIs as required.
+                '-t', 'x86',
+                '-t', 'x86_64',
                 '-o', '../android/app/src/main/jniLibs', 'build'
         if (profileMode != null) {
             args profileMode

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,7 +86,7 @@ dependencies {
         workingDir "../../native"
         environment ANDROID_NDK_HOME: "$ANDROID_NDK"
         commandLine 'cargo', 'ndk',
-                // the below 2 ABIs are used for target Android devices
+                // the 2 ABIs below are used by real Android devices
                 '-t', 'armeabi-v7a',
                 '-t', 'arm64-v8a',
                 // the below 2 ABIs are usually used for Android simulators,

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ dependencies {
                 '-t', 'armeabi-v7a',
                 '-t', 'arm64-v8a',
                 // the below 2 ABIs are usually used for Android simulators,
-                // comment these ABIs as required.
+                // add or remove these ABIs as needed.
                 '-t', 'x86',
                 '-t', 'x86_64',
                 '-o', '../android/app/src/main/jniLibs', 'build'


### PR DESCRIPTION
In file `android\app\build.gradle`, I modified it to make generation ABIs for x86 and x86_64 by default. Also, I add ed some comments to make them more understandable.

If this pr is accepted, I plan to add some pr to modify the article https://cjycode.com/flutter_rust_bridge/integrate/android_tasks.html.