### PR TITLE
Automatically link imported crates to binary

### DIFF
--- a/linux/rust.cmake
+++ b/linux/rust.cmake
@@ -14,12 +14,8 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Corrosion)
 
-corrosion_import_crate(MANIFEST_PATH ../native/Cargo.toml)
-
-# Flutter-specific
-
-set(CRATE_NAME "native")
-
-target_link_libraries(${BINARY_NAME} PRIVATE ${CRATE_NAME})
-
-list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${CRATE_NAME}-shared>)
+corrosion_import_crate(MANIFEST_PATH ../native/Cargo.toml IMPORTED_CRATES imported_crates)
+target_link_libraries(${BINARY_NAME} PRIVATE ${imported_crates})
+foreach(imported_crate ${imported_crates})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${imported_crate}-shared>)
+endforeach()

--- a/windows/rust.cmake
+++ b/windows/rust.cmake
@@ -14,12 +14,8 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Corrosion)
 
-corrosion_import_crate(MANIFEST_PATH ../native/Cargo.toml)
-
-# Flutter-specific
-
-set(CRATE_NAME "native")
-
-target_link_libraries(${BINARY_NAME} PRIVATE ${CRATE_NAME})
-
-list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${CRATE_NAME}-shared>)
+corrosion_import_crate(MANIFEST_PATH ../native/Cargo.toml IMPORTED_CRATES imported_crates)
+target_link_libraries(${BINARY_NAME} PRIVATE ${imported_crates})
+foreach(imported_crate ${imported_crates})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${imported_crate}-shared>)
+endforeach()


### PR DESCRIPTION
With this change in corrosion https://github.com/corrosion-rs/corrosion/pull/312, it is now possible to retrieve the list of imported crates by corrosion. This means that we do not need to manually do `target_link_libraries` one by one, crate by crate.

If the folder `native` is just a normal library crate, this PR wouldn't make such a big difference. However, if the `native` folder is a workspace crate, it means that many library crates are under that directory.

In short, with this PR, both situations are covered.
- When `native` is a library crate
- When `native` is a workspace crate containing multiple library crates