### PR TITLE
update justfile w --extra-c-output-path flag for macos codegen

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,6 +6,7 @@ gen:
         --rust-input native/src/api.rs \
         --dart-output lib/bridge_generated.dart \
         --c-output ios/Runner/bridge_generated.h \
+        --extra-c-output-path macos/Runner/ \
         --dart-decl-output lib/bridge_definitions.dart \
         --wasm
     cp ios/Runner/bridge_generated.h macos/Runner/bridge_generated.h

--- a/justfile
+++ b/justfile
@@ -9,7 +9,6 @@ gen:
         --extra-c-output-path macos/Runner/ \
         --dart-decl-output lib/bridge_definitions.dart \
         --wasm
-    cp ios/Runner/bridge_generated.h macos/Runner/bridge_generated.h
 
 lint:
     cd native && cargo fmt


### PR DESCRIPTION
Patch for [this](https://github.com/Desdaemon/flutter_rust_bridge_template/issues/41) issue.